### PR TITLE
Ajout de l'heure avant chaque traitement de PDF

### DIFF
--- a/resumer_gemma.py
+++ b/resumer_gemma.py
@@ -98,6 +98,10 @@ for chemin_pdf in tqdm(pdfs):
         print(f"⏭️  Déjà traité : {chemin_pdf}")
         continue
 
+    # Affichage de l'heure actuelle avant traitement
+    heure_actuelle = time.strftime("%Y-%m-%d %H:%M:%S")
+    print(f"🕒 Heure actuelle : {heure_actuelle}")
+
     texte = extraire_texte(chemin_pdf)
     nb_caract = len(texte)
     print(f"ℹ️  {chemin_pdf} — {nb_caract} caractères extraits")


### PR DESCRIPTION
## Summary
- affiche l'heure actuelle avant chaque appel au modèle dans `resumer_gemma.py`

## Testing
- `python -m py_compile resumer_gemma.py`


------
https://chatgpt.com/codex/tasks/task_e_688a277ead2c832bb8b809a231310d96